### PR TITLE
Fix ValidationError export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,4 +108,4 @@ export const betterAjvErrors = ({
   });
 };
 
-export { ValidationError } from 'types/ValidationError';
+export { ValidationError };


### PR DESCRIPTION
`'types/ValidationError'` ends up being resolved incorrectly when consuming this package from `npm`, with `moduleResolution: 'node'` configured in the TypeScript compiler.

You could alternatively switch it to `'./types/ValidationError'` (with the leading `./` making the path relative) but since `ValidationError` is already imported from that path earlier in the file, it doesn't seem necessary?