### PR TITLE
Removing publishConfig.registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "prettier": "^2.3.0"
   },
   "publishConfig": {
-    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "keywords": [


### PR DESCRIPTION
Explicitly specifying that the package be published to https://registry.npmjs.org keeps the package from being able to be installed to a private registry. See https://stackoverflow.com/questions/70962883/why-cant-i-publish-this-specific-package-to-a-private-npm-registry-hosted-by-ve.